### PR TITLE
Track when a gatherer is away or has left the gather

### DIFF
--- a/app/assets/stylesheets/themes/default/components/_gather.scss
+++ b/app/assets/stylesheets/themes/default/components/_gather.scss
@@ -202,3 +202,11 @@ table.gathers {
 ul.gatherers {
   @include span-columns(12);
 }
+
+ul#gatherers {
+  li.away a {
+    font-style: italic;
+    font-weight: normal;
+    color: #5b5b5b;
+  }
+}

--- a/app/controllers/gatherers_controller.rb
+++ b/app/controllers/gatherers_controller.rb
@@ -32,6 +32,22 @@ class GatherersController < ApplicationController
     redirect_to_back
   end
 
+  def status
+    raise AccessError unless @gatherer.can_destroy? cuser
+
+    states = {
+      "leaving" => Gatherer::STATE_LEAVING,
+      "away" => Gatherer::STATE_AWAY,
+      "active" => Gatherer::STATE_ACTIVE,
+    }
+
+    if states.has_key?(params[:status])
+      @gatherer.update_attribute(:status, states[params[:status]])
+    end
+
+    render :nothing => true, :status => 200
+  end
+
   def destroy
     raise AccessError unless @gatherer.can_destroy? cuser
 

--- a/app/controllers/gathers_controller.rb
+++ b/app/controllers/gathers_controller.rb
@@ -72,5 +72,24 @@ class GathersController < ApplicationController
     end
 
     @gatherer = @gather.gatherers.of_user(cuser).first if cuser
+    update_gatherers
+  end
+
+  def update_gatherers
+    # Update user that has left and came back
+    if @gatherer and @gatherer.status == Gatherer::STATE_LEAVING
+      @gatherer.update_attribute(:status, Gatherer::STATE_ACTIVE)
+    end
+
+    # Remove any users that left over 30 seconds ago
+    removed_users = false
+    @gather.gatherers.each do |gatherer|
+      if gatherer.status == Gatherer::STATE_LEAVING and gatherer.updated_at < Time.now - 30
+        removed_users = true
+        gatherer.destroy
+      end
+    end
+
+    @gather.reload if removed_users
   end
 end

--- a/app/models/gatherer.rb
+++ b/app/models/gatherer.rb
@@ -15,6 +15,10 @@ class Gatherer < ActiveRecord::Base
   IDLE_TIME = 600
   EJECT_VOTES = 4
 
+  STATE_ACTIVE = 0
+  STATE_AWAY = 1
+  STATE_LEAVING = 2
+
   include Extra
 
   attr_protected :id

--- a/app/views/gathers/_running.html.erb
+++ b/app/views/gathers/_running.html.erb
@@ -6,7 +6,7 @@
 
       <ul id="gatherers">
         <% @gather.gatherers.each do |gatherer| %>
-          <li>
+          <li<% if gatherer.status > 0 %> class="away"<% end %>>
             <%= flag gatherer.user.country %>
             <%= namelink gatherer.user %>
             <% if cuser and cuser.admin? %>

--- a/app/views/gathers/show.html.erb
+++ b/app/views/gathers/show.html.erb
@@ -1,6 +1,25 @@
 <div id="jplayer"></div>
 <script type="text/javascript">
   var played = false;
+  var leaving = true;
+  <% if @gatherer and @gatherer.can_destroy? cuser %>
+  var gatherer_id = <%= @gatherer.id %>;
+  <% else %>
+  var gatherer_id = 0;
+  <% end %>
+
+  function updateGathererStatus(status) {
+    $.ajax({
+      url: '/gatherers/' + gatherer_id + '/status',
+      type: 'POST',
+      data: {'status': status},
+      async: false,
+      cache: false,
+      success: function() {},
+      complete: function() {},
+      error: function() {}
+    });
+  }
 
   $(document).ready(function() {
     $.PeriodicalUpdater("/gathers/" + <%= @gather.id %> + ".js", {
@@ -38,6 +57,39 @@
         }
       }
     });
+
+    $(window).bind('beforeunload', function(e) {
+      if (gatherer_id > 0) {
+        return "You will be removed from the Gather if you leave this page.";
+      }
+    });
+
+    $(window).bind('unload', function() {
+      if (gatherer_id > 0) {
+        updateGathererStatus('leaving');
+      }
+    });
+
+    var afk = false;
+    var afk_timeout;
+    var afk_time = 1000 * 60 * 15; // 15 minutes
+    $(window).blur(function() {
+      afk_timeout = setTimeout(function() {
+        if (gatherer_id > 0) {
+          afk = true;
+          updateGathererStatus('away');
+        }
+      }, afk_time);
+    });
+
+    $(window).focus(function() {
+      if (afk) {
+        updateGathererStatus('active');
+        $.get("/gathers/" + <%= @gather.id %> + ".js");
+      }
+
+      clearTimeout(afk_timeout);
+    });
   });
 </script>
 
@@ -46,7 +98,7 @@
     <span>
       <%= link_to @gather do %>
         <%= @gather.category.to_s %> Gather
-      <% end %>  
+      <% end %>
     </span>
   </h1>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,9 @@ Ensl::Application.routes.draw do
 
   match 'gathers/refresh'
   match 'gathers/latest/:game', to: "gathers#latest", via: :get
-  match 'gather', to: "gathers#latest", game: "ns2", via: :get  
+  match 'gather', to: "gathers#latest", game: "ns2", via: :get
+
+  match 'gatherers/:id/status', to: "gatherers#status", via: :post
 
   match 'groups/addUser'
   match 'groups/delUser'

--- a/db/migrate/20141010193221_add_status_to_gatherer.rb
+++ b/db/migrate/20141010193221_add_status_to_gatherer.rb
@@ -1,0 +1,5 @@
+class AddStatusToGatherer < ActiveRecord::Migration
+  def change
+		add_column :gatherers, :status, :int, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140810224606) do
+ActiveRecord::Schema.define(:version => 20141010193221) do
 
   create_table "admin_requests", :force => true do |t|
     t.string   "addr"
@@ -294,6 +294,7 @@ ActiveRecord::Schema.define(:version => 20140810224606) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "votes",      :default => 0, :null => false
+    t.integer  "status",     :default => 0, :null => false
   end
 
   add_index "gatherers", ["gather_id"], :name => "index_gatherers_on_gather_id"
@@ -757,18 +758,6 @@ ActiveRecord::Schema.define(:version => 20140810224606) do
 
   add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
   add_index "sessions", ["updated_at"], :name => "index_sessions_on_updated_at"
-
-  create_table "shoutmsg_archive", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "text"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "shoutable_type"
-    t.integer  "shoutable_id"
-  end
-
-  add_index "shoutmsg_archive", ["shoutable_type", "shoutable_id"], :name => "index_shoutmsgs_on_shoutable_type_and_shoutable_id"
-  add_index "shoutmsg_archive", ["user_id"], :name => "index_shoutmsgs_on_user_id"
 
   create_table "shoutmsgs", :force => true do |t|
     t.integer  "user_id"


### PR DESCRIPTION
Added a status column to gatherers that will track whether the user is active, away, or has left the gather. The status will be updated from the client-side based on activity.

Leaving will be triggered when the user leaves the gather page. We have a 30 second timer in case the user is just refreshing or comes back quickly. This also adds a notice before the user leaves the page confirming that doing so will remove them from the gather.

In addition, this will also track if a user is actively viewing the page using the "blur" and "focus" window events. If the user does not have the gather page focused for more than 15 minutes then it will change their name in the player list to be italic and a gray color. In the future we can expand this to detect activity in other ways if necessary. Right now, away players are not removed from the gather automatically as long as they have the page open but it is something that can be considered.
