### PR TITLE
Fix error page for when the 404 is user not found

### DIFF
--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -6,13 +6,13 @@
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= favicon_link_tag 'shared/favicon.ico' %>
-    <%= stylesheet_link_tag "themes/#{active_theme}/errors" %>
+    <%= stylesheet_link_tag "themes/default/errors" %>
   </head>
   <body>
     <div id="error">
       <div class="message">
         <div id="logo">
-          <%= link_to image_tag("themes/#{active_theme}/logo.png"), root_path %>
+          <%= link_to image_tag("themes/default/logo.png"), root_path %>
         </div>
         <div id="code">
           <h1><%= params[:code] %></h1>


### PR DESCRIPTION
I think I found the cause of our non-deterministic CI errors on the develop branch. Hopefully should be green now

There was a race-condition which was playing out in CI test. Tests running on the headless browser were running async requests parallel to the salient test requests. Sometimes they would run after the test had finished and database_cleaner had wiped the database. This resulted (on occasion) a record not found error which renders a 404 page. We're getting errors because the 404 page also requires a user to render a theme if the browser is already signed in with a valid user. Since the user is deleted an `ActionView::Template::Error` would bubble up through the app

The fix is to remove the custom styling from error pages. I've set this to default. The async requests will still happen in the background and they will continue to 404 after the database cleaner has done its thing

