### PR TITLE
Revert session cookie changes in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,5 +63,5 @@ Ensl::Application.configure do
   config.active_support.deprecation = :notify
 
   # Custom Session Store config to allow gathers.staging.ensl.org
-  config.session_store :cookie_store, key: '_ENSL_session_key', expire_after: 30.days.to_i, domain: "gathers.ensl.org"
+  # config.session_store :cookie_store, key: '_ENSL_session_key', expire_after: 30.days.to_i, domain: "gathers.ensl.org"
 end


### PR DESCRIPTION
Need to figure out why this isn't working. In the meantime, disable in production