### PR TITLE
Expose new gathers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,4 +189,12 @@ module ApplicationHelper
   def latest_rules
     article_path(Article::RULES)
   end
+
+  def gathers_url
+    if Rails.env.production?
+      "http://gathers.ensl.org"
+    else
+      "http://gathers.staging.ensl.org"
+    end
+  end
 end

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -25,14 +25,19 @@
         </ul>
       </li>
       <li class="dropdown">
-        <%= active_link_to Gather.last, class: 'gathers' do %>
+        <%= link_to gathers_url, class: 'gathers', target: "_blank" do %>
           Gathers 
-          <span class="count"><%= Gather.player_count_for_game('NS2') %>/<%= Gather::FULL %></span>
+          <span class="count" id="gathercount"></span>
         <% end %>
-        
         <ul>
           <li><%= link_to "Introduction", article_url(464) %></li>
           <li><%= link_to "Archives", "/gathers/" %></li>
+          <li>
+            <%= active_link_to Gather.last, class: 'gathers' do %>
+              Fallback
+              <span class="count"><%= Gather.player_count_for_game('NS2') %>/<%= Gather::FULL %></span>
+            <% end %>
+          </li>
         </ul>
       </li>
       <li class="dropdown icon">
@@ -73,3 +78,14 @@
     </ul>
   </div>
 </nav>
+<script>
+$(function () {
+  $.ajax({
+    datatype: "json",
+    url: "<%= gathers_url %>/gathers/current", 
+    success: function (data) {
+      $("#gathercount").html(data.gatherers.length + "/12");
+    }
+  });
+});
+</script>

--- a/app/views/gathers/show.html.erb
+++ b/app/views/gathers/show.html.erb
@@ -143,6 +143,10 @@
     <% end %>
   </div>
 
+  <h4 class="fancy add-top">
+    Gathers have moved to <%= link_to "gathers.ensl.org", gathers_url, target: "_blank" %>. This app is just a fallback in case something goes wrong
+  </h4>
+
   <% if @gather and @gather.status != Gather::STATE_FINISHED %>
     <div id="gather-info">
       <div class="info">

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -32,9 +32,8 @@ describe Topic do
     it "returns 5 unique, most recently posted topics" do
       topics = []
       10.times do
-        topic = create :topic
-        topics << topic
-        3.times { create :post, topic: topic }
+        topic = create :topic, first_post: "Foo"
+        topics.push(topic)
       end
       recent_topics = Topic.recent_topics
       topics.last(5).each do |topic|


### PR DESCRIPTION
Merge this in & deploy when you're ready to trial gathers.ensl.org

Changes in this PR:

- Updates the navigation for Gathers to "http://gathers.ensl.org"
- Drops current Gathers link into navigation sub-menu (if something happens, people can always revert to old gathers app)
- Adds a notice on old gathers app about the redirect
- Draws Gather attendance from gathers.ensl.org api (gathers.ensl.org/gathers/current)