### PR TITLE
Improve SteamID validation

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::UsersController < Api::V1::BaseController
       time_zone: @user.time_zone,
       avatar: @user.profile.avatar.url,
       admin: @user.admin?,
-      steam: {
+      steam: @user.steamid.nil? ? nil : {
         id: @user.steamid,
         url: @steam.nil? ? nil : @steam.base_url,
         nickname: @steam.nil? ? nil : @steam.nickname

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,7 +5,9 @@ class Api::V1::UsersController < Api::V1::BaseController
 
   def show
     @user = User.find(params[:id])
-    @steam = steam_profile @user
+    if @user.steamid.present?
+      @steam = steam_profile @user
+    end
 
     render json: {
       id: @user.id,

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -33,14 +33,13 @@ class Ban < ActiveRecord::Base
   scope :effective, conditions: "expiry > UTC_TIMESTAMP()"
   scope :ineffective, conditions: "expiry < UTC_TIMESTAMP()"
 
+  before_validation :check_user
+
   validate :validate_type
   validate :validate_ventban
-  validates_length_of :steamid, maximum: 14, allow_blank: true
-  validates_format_of :steamid, with: /\A0:[01]:[0-9]{1,10}\Z/, allow_blank: true
-  validates_format_of :addr, with: /\A([0-9]{1,3}\.){3}[0-9]{1,3}:?[0-9]{0,5}\z/, allow_blank: true
-  validates_length_of :reason, maximum: 255, allow_nil: true, allow_blank: true
-
-  before_validation :check_user
+  validates :steamid, length: {maximum: 14}, format: /\A0:[01]:[0-9]{1,10}\Z/, allow_blank: true
+  validates :addr, format: /\A([0-9]{1,3}\.){3}[0-9]{1,3}:?[0-9]{0,5}\z/, allow_blank: true
+  validates :reason, length: {maximum: 255}, allow_blank: true
 
   belongs_to :user
   belongs_to :server

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -35,7 +35,8 @@ class Ban < ActiveRecord::Base
 
   validate :validate_type
   validate :validate_ventban
-  validates_format_of :steamid, with: /\A([0-9]{1,10}:){2}[0-9]{1,10}\Z/, allow_blank: true
+  validates_length_of :steamid, maximum: 14, allow_blank: true
+  validates_format_of :steamid, with: /\A0:[01]:[0-9]{1,10}\Z/, allow_blank: true
   validates_format_of :addr, with: /\A([0-9]{1,3}\.){3}[0-9]{1,3}:?[0-9]{0,5}\z/, allow_blank: true
   validates_length_of :reason, maximum: 255, allow_nil: true, allow_blank: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,24 +100,20 @@ class User < ActiveRecord::Base
   scope :idle,
     :conditions => ["lastvisit < ?", 30.minutes.ago.utc]
 
-  validates_uniqueness_of :username, :email
-  validates_uniqueness_of :steamid, :allow_nil => true
-  validates_length_of :firstname, :in => 1..15, :allow_blank => true
-  validates_length_of :lastname, :in => 1..25, :allow_blank => true
-  validates_length_of :username, :in => 2..20
-  validates_format_of :username, :with => /\A[A-Za-z0-9_\-\+]{2,20}\Z/
-    validates_presence_of :raw_password, :on => :create
-  validates_length_of :email, :maximum => 50
-  validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
-  validates_length_of :steamid, :maximum => 14
-  validates :steamid, presence: true, on: :create
+  before_validation :update_password
+
+  validates :username, uniqueness: true, length: {in: 2..20}, format: /\A[A-Za-z0-9_\-\+]{2,20}\Z/
+  validates :firstname, length: {in: 1..15}, allow_blank: true
+  validates :lastname, length: {in: 1..25}, allow_blank: true
+  validates :raw_password, presence: {on: :create}
+  validates :email, uniqueness: true, length: {maximum: 50}, format: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
+  validates :steamid, uniqueness: {allow_nil: true}, length: {maximum: 14}, presence: {on: :create}
   validate :validate_steamid
-    validates_length_of :time_zone, :maximum => 100, :allow_blank => true, :allow_nil => true
-  validates_inclusion_of [:public_email], :in => [true, false], :allow_nil => true
+  validates :time_zone, length: {maximum: 100}, allow_blank: true
+  validates :public_email, inclusion: [true, false], allow_nil: true
   validate :validate_team
 
   before_create :init_variables
-  before_validation :update_password
 
   before_save :correct_steamid_universe
 
@@ -243,15 +239,16 @@ class User < ActiveRecord::Base
   end
 
   def validate_steamid
-    errors.add :steamid unless self.steamid.nil? ||
-      (m = self.steamid.match(/\A([01]):([01]):(\d{1,10})\Z/)) &&
+    errors.add :steamid unless
+	  steamid.nil? ||
+      (m = steamid.match(/\A([01]):([01]):(\d{1,10})\Z/)) &&
       (id = m[3].to_i) &&
       id >= 1 && id <= 2147483647
   end
 
   def correct_steamid_universe
-    if self.steamid.present?
-      self.steamid[0] = "0"
+    if steamid.present?
+      steamid[0] = "0"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -243,13 +243,14 @@ class User < ActiveRecord::Base
   end
 
   def validate_steamid
-    if !(self.steamid.nil? || (m = self.steamid.match(/\A([01]):([01]):(\d{1,10})\Z/) and accid = (m[3].to_i<<1)+m[2].to_i and accid > 0 and accid <= 4294967295))
-      errors.add :steamid
-    end
+    errors.add :steamid unless self.steamid.nil? ||
+      (m = self.steamid.match(/\A([01]):([01]):(\d{1,10})\Z/)) &&
+      (id = m[3].to_i) &&
+      id >= 1 && id <= 2147483647
   end
 
   def correct_steamid_universe
-    if self.steamid
+    if self.steamid.present?
       self.steamid[0] = "0"
     end
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -29,16 +29,14 @@ describe Api::V1::UsersController do
       expect(json["team"]).to be_nil
     end
 
-    it "returns data for users with invalid steam ids" do
-      @user.steamid = "0:0:000"
+    it "returns nulled steam data for users who had invalid steam ids" do
+      @user.steamid = nil
       @user.save!
 
       get :show, id: @user.id
 
       expect(response).to be_success
-      expect(json["steam"]["id"]).to_not be_nil
-      expect(json["steam"]["url"]).to be_nil
-      expect(json["steam"]["nickname"]).to be_nil
+      expect(json["steam"]).to be_nil
     end
 
     it "returns 404 if user does not exist" do

--- a/spec/features/users/user_signs_up_spec.rb
+++ b/spec/features/users/user_signs_up_spec.rb
@@ -1,64 +1,64 @@
-require 'spec_helper'
+require "spec_helper"
 
-feature 'Visitor signs up', js: :true do
+feature "Visitor signs up", js: :true do
   let(:user) { attributes_for(:user) }
 
   before do
     visit new_user_path
   end
 
-  scenario 'with valid Username, Email, Password and Steam ID' do
+  scenario "with valid Username, Email, Password and Steam ID" do
     within registration_form do
       fill_form(:user, user.slice(*sign_up_attributes))
       click_button submit(:user, :create)
     end
     
-    expect(user_status).to have_content('ACCOUNT')
+    expect(user_status).to have_content("ACCOUNT")
   end
 
-  scenario 'with invalid Email' do
+  scenario "with invalid Email" do
     within registration_form do
-      fill_form(:user, user.slice(*sign_up_attributes).merge({ email: "invalid" }))
+      fill_form(:user, user.slice(*sign_up_attributes).merge(email: "invalid"))
       click_button submit(:user, :create)
     end
 
-    expect(page).to have_content(error_message('email.invalid'))
+    expect(page).to have_content(error_message("email.invalid"))
   end
 
-  scenario 'with blank Password' do
+  scenario "with blank Password" do
     within registration_form do
-      fill_form(:user, user.slice(*sign_up_attributes).merge({ raw_password: "" }))
+      fill_form(:user, user.slice(*sign_up_attributes).merge(raw_password: ""))
       click_button submit(:user, :create)
     end
 
-    expect(page).to have_content(error_message('raw_password.blank'))
+    expect(page).to have_content(error_message("raw_password.blank"))
   end
 
-  scenario 'with invalid Steam ID' do
+  scenario "with invalid Steam ID" do
     within registration_form do
-      fill_form(:user, user.slice(*sign_up_attributes).merge({ steamid: "invalid" }))
+      fill_form(:user, user.slice(*sign_up_attributes).merge(steamid: "invalid"))
       click_button submit(:user, :create)
     end
 
-    expect(page).to have_content(error_message('steamid.invalid'))
+    expect(page).to have_content(error_message("steamid.invalid"))
   end
 
-  scenario 'with out of range Steam ID' do
+  scenario "with out of range Steam ID" do
     within registration_form do
-      fill_form(:user, user.slice(*sign_up_attributes).merge({ steamid: "0:0:2147483648" }))
+      fill_form(:user, user.slice(*sign_up_attributes).merge(steamid: "0:0:2147483648"))
       click_button submit(:user, :create)
     end
 
-    expect(page).to have_content(error_message('steamid.invalid'))
+    expect(page).to have_content(error_message("steamid.invalid"))
   end
 
-  scenario 'with nil Steam ID' do
+  scenario "with nil Steam ID" do
     within registration_form do
-      fill_form(:user, user.slice(*sign_up_attributes).merge({ steamid: nil }))
+      fill_form(:user, user.slice(*sign_up_attributes).merge(steamid: nil))
       click_button submit(:user, :create)
     end
 
-    expect(page).to have_content(error_message('steamid.invalid'))
+    expect(page).to have_content(error_message("steamid.invalid"))
   end
 
   def sign_up_attributes

--- a/spec/features/users/user_signs_up_spec.rb
+++ b/spec/features/users/user_signs_up_spec.rb
@@ -43,6 +43,15 @@ feature 'Visitor signs up', js: :true do
     expect(page).to have_content(error_message('steamid.invalid'))
   end
 
+  scenario 'with out of range Steam ID' do
+    within registration_form do
+      fill_form(:user, user.slice(*sign_up_attributes).merge({ steamid: "0:0:2147483648" }))
+      click_button submit(:user, :create)
+    end
+
+    expect(page).to have_content(error_message('steamid.invalid'))
+  end
+
   def sign_up_attributes
     [:username, :email, :raw_password, :steamid]
   end

--- a/spec/features/users/user_signs_up_spec.rb
+++ b/spec/features/users/user_signs_up_spec.rb
@@ -52,6 +52,15 @@ feature 'Visitor signs up', js: :true do
     expect(page).to have_content(error_message('steamid.invalid'))
   end
 
+  scenario 'with nil Steam ID' do
+    within registration_form do
+      fill_form(:user, user.slice(*sign_up_attributes).merge({ steamid: nil }))
+      click_button submit(:user, :create)
+    end
+
+    expect(page).to have_content(error_message('steamid.invalid'))
+  end
+
   def sign_up_attributes
     [:username, :email, :raw_password, :steamid]
   end


### PR DESCRIPTION
For bans the regex is just a bit tighter. It will still allow account IDs that are out of range. Previous bans that don't fit this regex either use invalid SteamIDs or at least SteamIDs that NS2 and mods that currently check these bans would not recognise.

For users the regex has been tightened similarly. The regex itself is a little looser to allow for more flexibility with some values that might be output differently by more modern SteamID code. These SteamIDs are still completely valid, and are corrected on save to follow the format used by NS2, ensl.org, and mods that access it. SteamIDs that have account IDs outside of the possible range are considered invalid, but ones inside this range are still not verified in any way.

It also allows SteamIDs to be set to null in the DB and still pass validation, while not allowing null/blank values for user-entered data. I've tested this in a few ways but I'm not familiar with ruby/rails so it's entirely possible that there's still a way for a user to set their SteamID to null. I don't see that as being worse than intentionally making it invalid in the current system though.

The problems caused by SteamID values that don't pass validation (both in the current version and with these changes) seem to be minimal. Users can still log in and everything seems to work fine, but the lastip column of the users table will not be updated upon login.

Here is a list of users who currently have invalid SteamIDs, along with the query to null them: http://pastebin.com/9MtkrA4u