### PR TITLE
User view cleanup

### DIFF
--- a/app/views/users/_general.html.erb
+++ b/app/views/users/_general.html.erb
@@ -15,13 +15,15 @@
       <dd><%= @user.profile.town %></dd>
     <% end %>
 
-    <dt>SteamID</dt>
-    <dd>
-      <p><%= @user.steamid %></p>
-      <div id="steam-search" data-user-id="<%= @user.id %>">
-        <%= link_to "Search for Steam Account" %>  
-      </div>
-    </dd>
+    <% if !@user.steamid.blank? %>
+      <dt>SteamID</dt>
+      <dd>
+        <p><%= @user.steamid %></p>
+        <div id="steam-search" data-user-id="<%= @user.id %>">
+          <%= link_to "Search for Steam Account" %>  
+        </div>
+      </dd>
+    <% end %>
 
     <% if !@user.profile.stream.blank? %>
       <dt>Stream</dt>

--- a/app/views/users/_general.html.erb
+++ b/app/views/users/_general.html.erb
@@ -4,10 +4,17 @@
   <dl>
     <dt>Age</dt>
     <dd><%= @user.age %></dd>
-    <dt>Country</dt>
-    <dd><%= @user.country %></dd>
-    <dt>Town</dt>
-    <dd><%= @user.profile.town %></dd>
+
+    <% if !@user.country.blank? %>
+      <dt>Country</dt>
+      <dd><%= @user.country %></dd>
+    <% end %>
+
+    <% if !@user.profile.town.blank? %>
+      <dt>Town</dt>
+      <dd><%= @user.profile.town %></dd>
+    <% end %>
+
     <dt>SteamID</dt>
     <dd>
       <p><%= @user.steamid %></p>
@@ -15,9 +22,12 @@
         <%= link_to "Search for Steam Account" %>  
       </div>
     </dd>
-    <dt>Stream</dt>
-    <dd><%= @user.profile.stream.blank? ? "No Stream Provided" : @user.profile.stream %></dd>
-    </dd>
+
+    <% if !@user.profile.stream.blank? %>
+      <dt>Stream</dt>
+      <dd><%= @user.profile.stream %></dd>
+      </dd>
+    <% end %>
   </dl>
 
   <h4>Contact</h4>

--- a/spec/features/users/stream_spec.rb
+++ b/spec/features/users/stream_spec.rb
@@ -7,7 +7,7 @@ feature "User Stream Information" do
   feature "stream administration" do
     scenario "user updates their stream" do
       visit user_path(user)
-      expect(page).to have_content("No Stream Provided")
+      expect(page.html).to_not include("<dt>Stream</dt>")
       fill_login_form(user, password)
       click_button submit(:user, :login)
       visit edit_user_path(user)
@@ -17,6 +17,7 @@ feature "User Stream Information" do
       click_button "Update Profile"
       expect(page).to have_content(I18n.t(:users_update))
       visit user_path(user)
+      expect(page.html).to include("<dt>Stream</dt>")
       expect(page).to have_content(stream_url)
     end
   end


### PR DESCRIPTION
Stops showing titles/headers/whatever for empty profile fields on user pages