### PR TITLE
fallback gather link as fixed redirect link

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -34,6 +34,7 @@ class Article < ActiveRecord::Base
   EXTRA = 428
   SB_RULES = 450
   G_RULES = 464
+  COMPMOD = 998
 
   attr_protected :id, :updated_at, :created_at, :user_id, :version
 

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -19,6 +19,7 @@
         <% end %>
         <ul>
           <li><%= link_to "Rules", latest_rules %></li>
+          <li><%= link_to "Hall of Fame", article_url(Article::COMPMOD) %></li>
           <li><%= link_to "Historical", "/contests" %></li>
           <li><%= link_to "NS1 History", "/contests/historical/NS1" %></li>
           <li><%= link_to "NS2 History", "/contests/historical/NS2" %></li>

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -33,7 +33,7 @@
           <li><%= link_to "Introduction", article_url(464) %></li>
           <li><%= link_to "Archives", "/gathers/" %></li>
           <li>
-            <%= active_link_to Gather.last, class: 'gathers' do %>
+            <%= link_to "/gathers/latest/ns2", class: 'gathers' do %>
               Fallback
               <span class="count"><%= Gather.player_count_for_game('NS2') %>/<%= Gather::FULL %></span>
             <% end %>


### PR DESCRIPTION
changing the fallback gather link to point to "http://www.ensl.org/gathers/latest/ns2" to make sure it points to the correct gather even without the user having to reload the page first

- requested by mega Jan 01 2017