### PR TITLE
Also return users without a team on UserCollection service

### DIFF
--- a/app/services/api/v1/users_collection.rb
+++ b/app/services/api/v1/users_collection.rb
@@ -39,7 +39,6 @@ class Api::V1::UsersCollection < Api::V1::Collection
     .project(columns)
     .join(teams_table, Arel::Nodes::OuterJoin)
     .on(joins)
-    .where(users_table[:team_id].not_eq(nil))
     .order(users_table[:id])
   end
 


### PR DESCRIPTION
Currently the API (http://www.ensl.org/api/v1/users/) only returns users that have a primary team set; that's not the case for all users.