### PR TITLE
fixed gathercount not getting loaded immediatly

### DIFF
--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -80,16 +80,16 @@
   </div>
 </nav>
 <script>
-$(function () {
-  var gatherInterval = setInterval(function() {
+$((function gather () {
     $.ajax({
       datatype: "json",
       url: "<%= gathers_url %>/gathers/current", 
       success: function (data) {
         $("#gathercount").html(data.gatherers.length + "/12");
+      },
+      complete: function() {
+      	setTimeout(gather, 10000);
       }
     });
-  },10000);
-  
-});
+  })());
 </script>


### PR DESCRIPTION
gathercount was not loaded due to no default values when the page was loaded. Fixed it by changing the interval call to a timeout call.