### PR TITLE
Fixed new PMs not highlighted

### DIFF
--- a/app/assets/stylesheets/themes/default/mixins/_flashes.scss
+++ b/app/assets/stylesheets/themes/default/mixins/_flashes.scss
@@ -44,4 +44,8 @@
   display: inline-block;
   font-style: italic;
   padding: 0 3px;
+
+  a {
+    color: white;
+  }
 }

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -18,7 +18,11 @@
     <div id="inbox" class="tab">
       <% if cuser.received_messages.any? %>
         <% cuser.received_messages.reverse_each do |message| %>
-          <div class="message <% 'highlight' if cuser.new_messages.include?(message) %>">
+          <% if cuser.new_messages.include?(message) %>
+            <div class="message highlight">
+          <% else %>
+            <div class="message">
+          <% end %>
             <%= render partial: 'message', locals: { message: message } %>
           </div>
         <% end %>


### PR DESCRIPTION
the current highlighting logic did not work. It used some shortcut syntax. This commit expands it to make it work properly. It also adds some styles to make the highlight more readable.