### PR TITLE
Adjust user API specs to expect users without assigned teams.

### DIFF
--- a/spec/services/api/v1/users_collection_spec.rb
+++ b/spec/services/api/v1/users_collection_spec.rb
@@ -9,8 +9,8 @@ describe Api::V1::UsersCollection do
         3.times { create(:user) }
       end
 
-      it "returns 0 results" do
-        expect(collection.execute_query.size).to eq(0)
+      it "returns 3 results" do
+        expect(collection.execute_query.size).to eq(3)
       end
     end
 


### PR DESCRIPTION
In d5d804a56f416f3637cfa32b0129142f8a82ecd8, the user API was changed to
also return users without an assigned team, but specs were not adjusted.