### PR TITLE
Fixed issue#97

### DIFF
--- a/app/controllers/teamers_controller.rb
+++ b/app/controllers/teamers_controller.rb
@@ -1,11 +1,13 @@
 class TeamersController < ApplicationController
   def create
+    @old_application = (cuser.teamers.joining.count == 0) ? nil : cuser.teamers.joining.first
     @teamer = Teamer.new params[:teamer]
     raise AccessError unless @teamer.can_create? cuser, params[:teamer]
     @teamer.user = cuser unless cuser.admin?
 
     if @teamer.save
       flash[:notice] = t(:applying_team) + @teamer.team.to_s
+      @old_application && @old_application.destroy
     else
       flash[:error] = @teamer.errors.full_messages.to_s
     end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,18 +10,19 @@
   <% end %>
 
   <% if cuser && cuser.teamers %>
-    <% if cuser.teamers.joining.count == 0  && @team.active %>
-      <%= form_for @teamer do |f| %>
-        <%= f.error_messages %>
-        <%= f.hidden_field :user_id, :value => cuser.id %>
-        <%= f.hidden_field :team_id, :value => @team.id %>
-
+    <%= form_for @teamer do |f| %>
+      <%= f.error_messages %>
+      <%= f.hidden_field :user_id, :value => cuser.id %>
+      <%= f.hidden_field :team_id, :value => @team.id %>
+      <% if cuser.teamers.joining.count == 0  && @team.active %>
         <div class="controls inline">
-           <%= f.submit "Request To Join", class: 'button' %>
+          <%= f.submit "Request To Join", class: 'button' %>
+        </div>
+      <% elsif cuser.teamers.joining.first.team != @team %>
+        <div class="controls inline">
+          <%= f.submit "Request To Join", class: 'button', data: { confirm: "You have already requested to join #{cuser.teamers.joining.first.team}. Do you want to request to join #{@team} instead?" } %>
         </div>
       <% end %>
-    <% elsif cuser.teamers.joining.first.team != @team %>
-      <%= link_to 'Request To Join', edit_teamer_path("teamer" => cuser.teamers.joining.first), method: :get,confirm: "You have already requested to join #{cuser.teamers.joining.first.team}. Do you want to request to join #{@team} instead?", class: 'button' %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
Team join dates were wrong because of the join button at the team page only modifying the already pending team application by changing the team id.
It is creating a new one and deleting the old one now.
This fix adjustes the view to point to the correct endpoint aswell as the create method of the controller to act accordingly if the logged in user already has a pending application.