### PR TITLE
Made bans show who created them

### DIFF
--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -20,6 +20,7 @@ class BansController < ApplicationController
   def create
     @ban = Ban.new(params[:ban])
     raise AccessError unless @ban.can_create? cuser
+    @ban.creator = cuser
 
     if @ban.save
       flash[:notice] = t(:bans_create)

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -13,7 +13,7 @@
 #  updated_at :datetime
 #  ban_type   :integer
 #  ip         :string(255)
-#
+#  creator_id :integer
 
 class Ban < ActiveRecord::Base
   include Extra
@@ -43,6 +43,8 @@ class Ban < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :server
+
+  belongs_to :creator, foreign_key: 'creator_id', class_name: 'User'
 
   def color
     expiry.past? ? "green" : "red"

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -3,7 +3,7 @@
 </h1>
 
 <div class="wide box">
-  <%= cascade @ban, ["steamid", :user, "addr", :server, "expiry", "reason_b", "created_at"] %>
+  <%= cascade @ban, ["steamid", :user, "addr", :server, "expiry", "reason_b", "created_at", :creator] %>
 </div>
 
 <%= link_to "Back", bans_url %>

--- a/db/migrate/20170304191254_add_creator_to_bans.rb
+++ b/db/migrate/20170304191254_add_creator_to_bans.rb
@@ -1,0 +1,6 @@
+class AddCreatorToBans < ActiveRecord::Migration
+  def change
+    add_column :bans, :creator_id, :integer
+    add_index :bans, :creator_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150820223313) do
+ActiveRecord::Schema.define(:version => 20170304191254) do
 
   create_table "admin_requests", :force => true do |t|
     t.string   "addr"
@@ -69,8 +69,10 @@ ActiveRecord::Schema.define(:version => 20150820223313) do
     t.datetime "updated_at"
     t.integer  "ban_type"
     t.string   "ip"
+    t.integer  "creator_id"
   end
 
+  add_index "bans", ["creator_id"], :name => "index_bans_on_creator_id"
   add_index "bans", ["server_id"], :name => "index_bans_on_server_id"
   add_index "bans", ["user_id"], :name => "index_bans_on_user_id"
 


### PR DESCRIPTION
To have a better overview on who created a ban this information is now stored and shown on the page of a specific ban. This information is not showing in the overall list though.
This feature was added to prevent abuse of the ban functionality.