### PR TITLE
Added Button to show user history for admins

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,5 +43,8 @@
     <%= link_to 'Edit', edit_user_path(@user), class: 'button' %>
     <%= link_to 'My Agenda', "/users/agenda/#{cuser.id}", class: 'button' %>
   <% end %>
+  <% if cuser and cuser.admin? %>
+    <%= link_to 'Show History', "/users/history/#{@user.id}", class: 'button' %>
+  <% end %>
 </div>
 


### PR DESCRIPTION
Showing a users version history was not obvious to admins. Added a button on a user show page for admins only so they can easily view this information.