### PR TITLE
Fix users API when nothing found

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -14,7 +14,8 @@ class Api::V1::UsersController < Api::V1::BaseController
     end
 
     if @user.nil?
-      raise ActionController::RoutingError.new("User Not Found")
+      render json: nil
+      return
     end
 
     if @user.steamid.present?


### PR DESCRIPTION
Renders nil with JSON (so it outputs null, a valid JSON response) when a search for a user didn't find one.

Currently the API raises a routing error when a user isn't found, which doesn't bubble up to the returned page. This makes it impossible to tell whether there was actually an error or if the user just wasn't found.