### PR TITLE
Fix my fix of the users API (oops)

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -51,7 +51,7 @@ class Api::V1::UsersController < Api::V1::BaseController
   private
 
   def not_found
-    head :not_found
+    render json: {error: "User not found"}, status: :not_found
   end
 
   def steam_profile(user)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::UsersController < Api::V1::BaseController
     end
 
     if @user.nil?
-      render json: nil, status: :not_found
+      not_found
       return
     end
 
@@ -45,10 +45,14 @@ class Api::V1::UsersController < Api::V1::BaseController
       team: @user.team.present? ? { id: @user.team.id, name: @user.team.name } : nil
     }
   rescue ActiveRecord::RecordNotFound
-    raise ActionController::RoutingError.new("User Not Found")
+    not_found
   end
 
   private
+
+  def not_found
+    head :not_found
+  end
 
   def steam_profile(user)
     SteamCondenser::Community::SteamId.from_steam_id("STEAM_#{user.steamid}")

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -78,11 +78,13 @@ describe Api::V1::UsersController do
     end
 
     it "returns 404 if user does not exist" do
-      expect { get :show, id: -1 }.to raise_error(ActionController::RoutingError)
+      get :show, id: -1
+      expect(response.status).to eq(404)
     end
 
     it "returns 404 if user does not exist by steamid" do
-      expect { get :show, id: -1, format: "steamid" }.to raise_error(ActionController::RoutingError)
+      get :show, id: -1, format: "steamid"
+      expect(response.status).to eq(404)
     end
 
     it "queries the steam condenser for an invalid steamid" do

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -80,11 +80,13 @@ describe Api::V1::UsersController do
     it "returns 404 if user does not exist" do
       get :show, id: -1
       expect(response.status).to eq(404)
+      expect(json["error"]).to eq("User not found")
     end
 
     it "returns 404 if user does not exist by steamid" do
       get :show, id: -1, format: "steamid"
       expect(response.status).to eq(404)
+      expect(json["error"]).to eq("User not found")
     end
 
     it "queries the steam condenser for an invalid steamid" do


### PR DESCRIPTION
Following up from #103 

I didn't have rspec running yet and I was lazy so I missed the other RoutingError that was raised by the API for other request types; and I completely forgot about the spec. Also, I was wrong: nil is not turned into a valid JSON response for the majority of parsers. Absurdon pointed out that returning a 404 would be better, so the API will now return an empty 404 response for bad requests.