### PR TITLE
Update Discord link in staff page

### DIFF
--- a/app/views/about/staff.html.erb
+++ b/app/views/about/staff.html.erb
@@ -7,7 +7,7 @@
 <p>
   <ol>
     <li>Use the <%= link_to 'contact', new_issue_path %> form</li>
-    <li>Join our official <%= link_to 'discord', 'https://discord.gg/Zpp4SAS' %></li>
+    <li>Join our official <%= link_to 'discord', 'https://discord.gg/Bvs3KjX' %></li>
     <li>Send email to the head admin as per the list below (mind that some email adresses are not shown due to privacy settings)</li>
     <li>Contact other staff members directly, check below and click profile for contact details</li>
   </ol>


### PR DESCRIPTION
old link is dead, update with a working link